### PR TITLE
Fix script generator API endpoint paths

### DIFF
--- a/api/mock-server.js
+++ b/api/mock-server.js
@@ -6,7 +6,7 @@ const port = 8000;
 app.use(cors());
 app.use(express.json());
 
-app.post('/script', (req, res) => {
+app.post('/api/script', (req, res) => {
   const { theme } = req.body;
   
   if (!theme) {

--- a/api/mock-server.js
+++ b/api/mock-server.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const cors = require('cors');
+const app = express();
+const port = 8000;
+
+app.use(cors());
+app.use(express.json());
+
+app.post('/script', (req, res) => {
+  const { theme } = req.body;
+  
+  if (!theme) {
+    return res.status(400).json({ error: 'Theme is required' });
+  }
+  
+  setTimeout(() => {
+    res.json({
+      script: `# ${theme}に関するスクリプト\n\nこんにちは、今日は${theme}について話します。\n\n${theme}は現代社会において非常に重要なトピックです。多くの人々が日々この問題に直面しています。\n\nまず、${theme}の基本的な概念を理解することが大切です。次に、実践的なアプローチを考えていきましょう。\n\n最後に、${theme}を日常生活に取り入れる方法をご紹介します。`,
+      alt: `# 別の${theme}スクリプト\n\n皆さん、${theme}について考えたことはありますか？\n\n今日は${theme}の魅力と可能性について探っていきます。\n\n${theme}は私たちの生活を豊かにする可能性を秘めています。具体的な例を見ていきましょう。\n\n1. ${theme}の歴史\n2. 現代における${theme}の役割\n3. 未来の${theme}の展望\n\nぜひコメントで皆さんの${theme}体験を教えてください！`
+    });
+  }, 1500);
+});
+
+app.listen(port, () => {
+  console.log(`Mock API server running at http://localhost:${port}`);
+  console.log('Mock API ready');
+});

--- a/backend/app/routers/script.py
+++ b/backend/app/routers/script.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+
+router = APIRouter()
+
+class ThemeRequest(BaseModel):
+    theme: str
+
+class ScriptResponse(BaseModel):
+    script: str
+    alt: str
+
+@router.post("/script", response_model=ScriptResponse)
+async def generate_script(request: ThemeRequest):
+    """
+    Generate two script options based on the provided theme.
+    """
+    if not request.theme:
+        raise HTTPException(status_code=400, detail="Theme is required")
+    
+    script = f"# {request.theme}に関するスクリプト\n\nこんにちは、今日は{request.theme}について話します。\n\n{request.theme}は現代社会において非常に重要なトピックです。多くの人々が日々この問題に直面しています。\n\nまず、{request.theme}の基本的な概念を理解することが大切です。次に、実践的なアプローチを考えていきましょう。\n\n最後に、{request.theme}を日常生活に取り入れる方法をご紹介します。"
+    alt = f"# 別の{request.theme}スクリプト\n\n皆さん、{request.theme}について考えたことはありますか？\n\n今日は{request.theme}の魅力と可能性について探っていきます。\n\n{request.theme}は私たちの生活を豊かにする可能性を秘めています。具体的な例を見ていきましょう。\n\n1. {request.theme}の歴史\n2. 現代における{request.theme}の役割\n3. 未来の{request.theme}の展望\n\nぜひコメントで皆さんの{request.theme}体験を教えてください！"
+    
+    return ScriptResponse(script=script, alt=alt)

--- a/backend/app/routers/script.py
+++ b/backend/app/routers/script.py
@@ -11,7 +11,7 @@ class ScriptResponse(BaseModel):
     script: str
     alt: str
 
-@router.post("/script", response_model=ScriptResponse)
+@router.post("/api/script", response_model=ScriptResponse)
 async def generate_script(request: ThemeRequest):
     """
     Generate two script options based on the provided theme.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from "react";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Textarea } from "../components/ui/textarea";
+import { useToast } from "../components/ui/toast/use-toast";
+import { Toaster } from "../components/ui/toast/toaster";
+import { Loader2 } from "lucide-react";
+
+type Stage = "theme" | "options" | "edit";
+type Script = {
+  script: string;
+  alt: string;
+};
+
+export default function Home() {
+  const [stage, setStage] = useState<Stage>("theme");
+  const [theme, setTheme] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [scripts, setScripts] = useState<Script | null>(null);
+  const [selectedScript, setSelectedScript] = useState<string>("");
+  const [editedScript, setEditedScript] = useState("");
+  const { toast } = useToast();
+
+  const handleThemeSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!theme.trim()) return;
+    
+    setIsLoading(true);
+    toast({
+      title: "生成中...",
+      description: "スクリプトを生成しています",
+      duration: 5000,
+    });
+    
+    try {
+      const response = await fetch("http://localhost:8000/script", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ theme }),
+      });
+      
+      if (!response.ok) {
+        throw new Error("Failed to generate scripts");
+      }
+      
+      const data = await response.json();
+      setScripts(data);
+      setStage("options");
+    } catch (error) {
+      console.error("Error generating scripts:", error);
+      toast({
+        title: "エラー",
+        description: "スクリプト生成に失敗しました。もう一度お試しください。",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleScriptSelect = (script: string) => {
+    setSelectedScript(script);
+    setEditedScript(script);
+    setStage("edit");
+  };
+
+  const handleSaveScript = () => {
+    setSelectedScript(editedScript);
+    
+    toast({
+      title: "保存しました！",
+      description: "スクリプトが正常に保存されました。",
+    });
+  };
+
+  const renderStage = () => {
+    switch (stage) {
+      case "theme":
+        return (
+          <div className="space-y-6">
+            <div className="text-center">
+              <h1 className="text-2xl font-bold">スクリプト生成</h1>
+              <p className="text-gray-500">テーマを入力してスクリプトを生成してください</p>
+            </div>
+            
+            <form onSubmit={handleThemeSubmit} className="space-y-4">
+              <div>
+                <Input
+                  placeholder="スクリプトのテーマを入力..."
+                  value={theme}
+                  onChange={(e) => setTheme(e.target.value)}
+                  disabled={isLoading}
+                />
+              </div>
+              
+              <Button type="submit" disabled={isLoading || !theme.trim()}>
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                スクリプト生成
+              </Button>
+            </form>
+          </div>
+        );
+        
+      case "options":
+        return (
+          <div className="space-y-6">
+            <div className="text-center">
+              <h1 className="text-2xl font-bold">選択</h1>
+              <p className="text-gray-500">生成されたスクリプトから選択してください</p>
+            </div>
+            
+            {scripts && (
+              <div className="grid grid-cols-1 gap-4">
+                <Button 
+                  variant="outline"
+                  className="h-auto p-4 flex flex-col items-start text-left"
+                  onClick={() => handleScriptSelect(scripts.script)}
+                >
+                  <div className="text-sm whitespace-pre-line">
+                    {scripts.script}
+                  </div>
+                </Button>
+                
+                <Button 
+                  variant="outline"
+                  className="h-auto p-4 flex flex-col items-start text-left"
+                  onClick={() => handleScriptSelect(scripts.alt)}
+                >
+                  <div className="text-sm whitespace-pre-line">
+                    {scripts.alt}
+                  </div>
+                </Button>
+              </div>
+            )}
+            
+            <Button onClick={() => setStage("theme")}>
+              テーマに戻る
+            </Button>
+          </div>
+        );
+        
+      case "edit":
+        return (
+          <div className="space-y-6">
+            <div className="text-center">
+              <h1 className="text-2xl font-bold">編集 &amp; 保存</h1>
+              <p className="text-gray-500">選択したスクリプトを編集してください</p>
+            </div>
+            
+            <div className="space-y-4">
+              <Textarea
+                value={editedScript}
+                onChange={(e) => setEditedScript(e.target.value)}
+                className="min-h-[300px]"
+              />
+              
+              <div className="flex justify-end space-x-2">
+                <Button 
+                  variant="outline" 
+                  onClick={() => setStage("options")}
+                >
+                  選択に戻る
+                </Button>
+                <Button onClick={handleSaveScript}>
+                  スクリプトを保存
+                </Button>
+              </div>
+            </div>
+          </div>
+        );
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-8">
+      <div className="container max-w-2xl mx-auto px-4">
+        <div className="bg-white rounded-lg shadow-sm p-6">
+          <div className="flex justify-center mb-6">
+            <div className="flex space-x-4">
+              <div className={`flex flex-col items-center ${stage === "theme" ? "text-blue-600 font-medium" : "text-gray-400"}`}>
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center ${stage === "theme" ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-400"}`}>
+                  1
+                </div>
+                <span className="text-sm mt-1">テーマ</span>
+              </div>
+              
+              <div className={`flex flex-col items-center ${stage === "options" ? "text-blue-600 font-medium" : "text-gray-400"}`}>
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center ${stage === "options" ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-400"}`}>
+                  2
+                </div>
+                <span className="text-sm mt-1">選択</span>
+              </div>
+              
+              <div className={`flex flex-col items-center ${stage === "edit" ? "text-blue-600 font-medium" : "text-gray-400"}`}>
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center ${stage === "edit" ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-400"}`}>
+                  3
+                </div>
+                <span className="text-sm mt-1">編集 &amp; 保存</span>
+              </div>
+            </div>
+          </div>
+          
+          {renderStage()}
+        </div>
+      </div>
+      <Toaster />
+    </main>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ export default function Home() {
     });
     
     try {
-      const response = await fetch("http://localhost:8000/script", {
+      const response = await fetch("http://localhost:8000/api/script", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/tests/playwright.spec.ts
+++ b/tests/playwright.spec.ts
@@ -10,7 +10,7 @@ test('Script Generator End-to-End Flow', async ({ page }) => {
   await page.getByRole('button', { name: 'スクリプト生成' }).click();
   
   await page.waitForResponse(response => 
-    response.url().includes('/script') && response.status() === 200
+    response.url().includes('/api/script') && response.status() === 200
   );
   
   await expect(page.getByRole('heading', { name: '選択' })).toBeVisible();

--- a/tests/playwright.spec.ts
+++ b/tests/playwright.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test('Script Generator End-to-End Flow', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  
+  await expect(page.getByRole('heading', { name: 'スクリプト生成' })).toBeVisible();
+  
+  await page.getByPlaceholder('スクリプトのテーマを入力...').fill('AIで英語学習');
+  
+  await page.getByRole('button', { name: 'スクリプト生成' }).click();
+  
+  await page.waitForResponse(response => 
+    response.url().includes('/script') && response.status() === 200
+  );
+  
+  await expect(page.getByRole('heading', { name: '選択' })).toBeVisible();
+  
+  const optionButtons = page.getByRole('button', { name: /AIで英語学習/ });
+  await expect(optionButtons).toHaveCount(2);
+  
+  await optionButtons.first().click();
+  
+  await expect(page.getByRole('heading', { name: '編集 & 保存' })).toBeVisible();
+  
+  const textarea = page.getByRole('textbox');
+  await textarea.fill('AIで英語学習のカスタムスクリプト');
+  
+  await page.getByRole('button', { name: 'スクリプトを保存' }).click();
+  
+  await expect(page.getByText('保存しました！')).toBeVisible();
+});


### PR DESCRIPTION
# Fix Script Generator API Endpoint Paths

This PR fixes the script generator functionality by standardizing all API endpoint paths to use `/api/script` consistently across the codebase.

## Changes Made

- Updated mock API server endpoint from `/script` to `/api/script`
- Updated FastAPI router endpoint from `/script` to `/api/script`
- Updated frontend fetch URL from `http://localhost:8000/script` to `http://localhost:8000/api/script`
- Updated Playwright test to look for `/api/script` in the response URL

## Testing

- Verified that the Playwright E2E test passes successfully
- Manually tested the application locally to confirm the full workflow functions correctly:
  1. Theme input → Generate Options
  2. Option selection (2 buttons displayed correctly)
  3. Edit & Save with toast notification

## Definition of Done

- [x] API endpoint paths standardized to `/api/script`
- [x] Playwright tests pass
- [x] Manual testing confirms functionality

Link to Devin run: https://app.devin.ai/sessions/ce35fc3e26a3409dbc746a0450740a17
Requested by: yusuke_minari@pdytokyo.com
